### PR TITLE
代码块使用等宽字体

### DIFF
--- a/static/css/code-dark.css
+++ b/static/css/code-dark.css
@@ -7,6 +7,7 @@ html.dark pre.highlight {
 html.dark .highlight pre {
   /* background: #282c34; */
   background: #161b22;
+  font-family: monospace;
 }
 html.dark .highlight .hll {
   background: #282c34;

--- a/static/css/code-light.css
+++ b/static/css/code-light.css
@@ -1,3 +1,6 @@
+.highlight pre {
+  font-family: monospace;
+}
 .highlight table td {
   padding: 5px;
 }


### PR DESCRIPTION
我好几年前 fork 的这个主题，前段时间升级之后发现代码块变成普通字体了，请问这是偏好还是 bug 啊？

我试着改回来了，你看一下可以不？